### PR TITLE
Update position for system install check

### DIFF
--- a/src/pip/_internal/commands/install.py
+++ b/src/pip/_internal/commands/install.py
@@ -249,9 +249,6 @@ class InstallCommand(RequirementCommand):
         if options.upgrade:
             upgrade_strategy = options.upgrade_strategy
 
-        if not options.use_user_site and not options.target_dir and not options.root_path and not options.prefix_path and not os.getenv('GENTOO_PIP_TESTING'):
-            raise CommandError("(Gentoo) Please run pip with the --user option to avoid breaking python-exec")
-
         cmdoptions.check_dist_restriction(options, check_target=True)
 
         install_options = options.install_options or []
@@ -308,6 +305,9 @@ class InstallCommand(RequirementCommand):
 
         try:
             reqs = self.get_requirements(args, options, finder, session)
+
+            if not options.use_user_site and not options.target_dir and not options.root_path and not options.prefix_path and not os.getenv('GENTOO_PIP_TESTING'):
+                raise CommandError("(Gentoo) Please run pip with the --user option to avoid breaking python-exec")
 
             reject_location_related_install_options(reqs, options.install_options)
 


### PR DESCRIPTION
This new position is a little later, but just before pip's check for
correct install location. This enables basic check the arguments
before failing, which enables printing of help message when no
argument is given to `pip install`.

Signed-off-by: Arthur Zamarin <arthurzam@gentoo.org>